### PR TITLE
Sets higher memory limit for init_container tests

### DIFF
--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -131,7 +131,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-								v1.ResourceMemory: *resource.NewQuantity(30*1024*1024, resource.DecimalSI),
+								v1.ResourceMemory: *resource.NewQuantity(50*1024*1024, resource.DecimalSI),
 							},
 						},
 					},
@@ -193,7 +193,7 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-								v1.ResourceMemory: *resource.NewQuantity(30*1024*1024, resource.DecimalSI),
+								v1.ResourceMemory: *resource.NewQuantity(50*1024*1024, resource.DecimalSI),
 							},
 						},
 					},


### PR DESCRIPTION
Currently, the limit set in the tests is 30 MB, which will cause
the Docker service on the Windows nodes to hang and be no longer
responsive. This will cause the Kubelet service to enter a NotReady state.

Setting a higher memory limit (50 MB) will avoid this issue.

