### PR TITLE
Removes PQDNs from conformance tests and places them in their own tests

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -44,9 +44,9 @@ var _ = SIGDescribe("DNS", func() {
 	framework.ConformanceIt("should provide DNS for the cluster ", func() {
 		// All the names we need to be able to resolve.
 		// TODO: Spin up a separate test service and test that dns works for that service.
+		// NOTE: This only contains the FQDN and the Host name, for testing partial name, see the test below
 		namesToResolve := []string{
-			"kubernetes.default",
-			"kubernetes.default.svc",
+			"kubernetes",
 			"kubernetes.default.svc.cluster.local",
 		}
 		// Added due to #8512. This is critical for GCE and GKE deployments.
@@ -67,12 +67,40 @@ var _ = SIGDescribe("DNS", func() {
 		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
+
+	It("should resolve DNS of partial qualified names for the cluster ", func() {
+		// All the names we need to be able to resolve.
+		// TODO: Spin up a separate test service and test that dns works for that service.
+		namesToResolve := []string{
+			"kubernetes.default",
+			"kubernetes.default.svc",
+			"kubernetes.default.svc.cluster",
+		}
+		// Added due to #8512. This is critical for GCE and GKE deployments.
+		if framework.ProviderIs("gce", "gke") {
+			namesToResolve = append(namesToResolve, "google.com")
+			namesToResolve = append(namesToResolve, "metadata")
+		}
+		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.cluster.local", dnsTestPodHostName, dnsTestServiceName, f.Namespace.Name)
+		hostEntries := []string{hostFQDN, dnsTestPodHostName}
+		wheezyProbeCmd, wheezyFileNames := createProbeCommand(namesToResolve, hostEntries, "", "wheezy", f.Namespace.Name)
+		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, hostEntries, "", "jessie", f.Namespace.Name)
+		By("Running these commands on wheezy: " + wheezyProbeCmd + "\n")
+		By("Running these commands on jessie: " + jessieProbeCmd + "\n")
+
+		// Run a pod which probes DNS and exposes the results by HTTP.
+		By("creating a pod to probe DNS")
+		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
+		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+	})
+	
 	/*
 		Release : v1.9
 		Testname: DNS, services
 		Description: When a headless service is created, the service MUST be able to resolve all the required service endpoints. When the service is created, any pod in the same namespace must be able to resolve the service by all of the expected DNS names.
 	*/
 	framework.ConformanceIt("should provide DNS for services ", func() {
+		// NOTE: This only contains the FQDN and the Host name, for testing partial name, see the test below
 		// Create a test headless service.
 		By("Creating a test headless service")
 		testServiceSelector := map[string]string{
@@ -102,6 +130,53 @@ var _ = SIGDescribe("DNS", func() {
 		// for headless service.
 		namesToResolve := []string{
 			fmt.Sprintf("%s", headlessService.Name),
+			fmt.Sprintf("%s.%s.svc.cluster.local", headlessService.Name, f.Namespace.Name),
+			fmt.Sprintf("_http._tcp.%s.%s.svc.cluster.local", headlessService.Name, f.Namespace.Name),
+			fmt.Sprintf("_http._tcp.%s.%s.svc.cluster.local", regularService.Name, f.Namespace.Name),
+		}
+
+		wheezyProbeCmd, wheezyFileNames := createProbeCommand(namesToResolve, nil, regularService.Spec.ClusterIP, "wheezy", f.Namespace.Name)
+		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, nil, regularService.Spec.ClusterIP, "jessie", f.Namespace.Name)
+		By("Running these commands on wheezy: " + wheezyProbeCmd + "\n")
+		By("Running these commands on jessie: " + jessieProbeCmd + "\n")
+
+		// Run a pod which probes DNS and exposes the results by HTTP.
+		By("creating a pod to probe DNS")
+		pod := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, dnsTestPodHostName, dnsTestServiceName)
+		pod.ObjectMeta.Labels = testServiceSelector
+
+		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
+	})
+
+	It("should resolve DNS of partial qualified names for services ", func() {
+		// Create a test headless service.
+		By("Creating a test headless service")
+		testServiceSelector := map[string]string{
+			"dns-test": "true",
+		}
+		headlessService := framework.CreateServiceSpec(dnsTestServiceName, "", true, testServiceSelector)
+		_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(headlessService)
+		Expect(err).NotTo(HaveOccurred(), "failed to create headless service: %s", dnsTestServiceName)
+		defer func() {
+			By("deleting the test headless service")
+			defer GinkgoRecover()
+			f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(headlessService.Name, nil)
+		}()
+
+		regularServiceName := "test-service-2"
+		regularService := framework.CreateServiceSpec(regularServiceName, "", false, testServiceSelector)
+		regularService, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(regularService)
+		Expect(err).NotTo(HaveOccurred(), "failed to create regular service: %s", regularServiceName)
+		defer func() {
+			By("deleting the test service")
+			defer GinkgoRecover()
+			f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(regularService.Name, nil)
+		}()
+
+		// All the names we need to be able to resolve.
+		// TODO: Create more endpoints and ensure that multiple A records are returned
+		// for headless service.
+		namesToResolve := []string{
 			fmt.Sprintf("%s.%s", headlessService.Name, f.Namespace.Name),
 			fmt.Sprintf("%s.%s.svc", headlessService.Name, f.Namespace.Name),
 			fmt.Sprintf("_http._tcp.%s.%s.svc", headlessService.Name, f.Namespace.Name),
@@ -121,6 +196,7 @@ var _ = SIGDescribe("DNS", func() {
 		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
+	
 	It("should provide DNS for pods for Hostname and Subdomain", func() {
 		// Create a test headless service.
 		By("Creating a test headless service")


### PR DESCRIPTION
Putting the partially qualified domain names into separate tests, so that so that we have a better idea of the state of our tests moving forward. 